### PR TITLE
Remove usage of deprecated pytest.config

### DIFF
--- a/test_package/conftest.py
+++ b/test_package/conftest.py
@@ -29,6 +29,16 @@ from test_tools import disk_utils
 LOGGER = logging.getLogger(__name__)
 
 
+pytest_options = {}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def get_pytest_options(request):
+    pytest_options["remote"] = request.config.getoption("--remote")
+    pytest_options["branch"] = request.config.getoption("--repo-tag")
+    pytest_options["force_reinstall"] = request.config.getoption("--force-reinstall")
+
+
 @pytest.fixture()
 def prepare_and_cleanup(request):
     """
@@ -99,15 +109,15 @@ def pytest_addoption(parser):
 
 
 def get_remote():
-    return pytest.config.getoption("--remote")
+    return pytest_options["remote"]
 
 
 def get_branch():
-    return pytest.config.getoption("--repo-tag")
+    return pytest_options["branch"]
 
 
 def get_force_param():
-    return pytest.config.getoption("--force-reinstall")
+    return pytest_options["force_reinstall"]
 
 
 def base_prepare():


### PR DESCRIPTION
In some versions of pytest this even stopped the execution entirely instead of just printing warnings.

Signed-off-by: Kamil Lepek <kamil.lepek94@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/test-framework/24)
<!-- Reviewable:end -->
