### PR TITLE
Add is_active() and wait_for_connection() to BaseExecutor

### DIFF
--- a/connection/base_executor.py
+++ b/connection/base_executor.py
@@ -11,6 +11,12 @@ class BaseExecutor:
     def _execute(self, command, timeout):
         raise NotImplementedError()
 
+    def is_active(self):
+        return True
+
+    def wait_for_connection(self):
+        pass
+
     def run(self, command, timeout: timedelta = timedelta(minutes=30)):
         if TestRun.dut and TestRun.dut.env:
             command = f"{TestRun.dut.env} && {command}"


### PR DESCRIPTION
This allows to avoid error-prone class type checks by providing
common interface for all executors.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>