### PR TITLE
Provide "remote_only" test marker

### DIFF
--- a/connection/base_executor.py
+++ b/connection/base_executor.py
@@ -11,6 +11,9 @@ class BaseExecutor:
     def _execute(self, command, timeout):
         raise NotImplementedError()
 
+    def is_remote(self):
+        return False
+
     def is_active(self):
         return True
 

--- a/connection/ssh_executor.py
+++ b/connection/ssh_executor.py
@@ -49,6 +49,16 @@ class SshExecutor(BaseExecutor):
 
         return Output(stdout.read(), stderr.read(), stdout.channel.recv_exit_status())
 
+    def is_remote(self):
+        return True
+
+    def is_active(self):
+        try:
+            self.ssh.exec_command('', timeout=5)
+            return True
+        except Exception:
+            return False
+
     def wait_for_connection(self, timeout: timedelta = timedelta(minutes=10)):
         TestRun.LOGGER.info("Waiting for DUT ssh connection...")
         start_time = datetime.now()
@@ -60,10 +70,3 @@ class SshExecutor(BaseExecutor):
                 continue
             except Exception:
                 continue
-
-    def is_active(self):
-        try:
-            self.ssh.exec_command('', timeout=5)
-            return True
-        except Exception:
-            return False

--- a/core/test_run_utils.py
+++ b/core/test_run_utils.py
@@ -23,6 +23,10 @@ def __configure(cls, config):
         "markers",
         "require_disk(name, type): require disk of specific type, otherwise skip"
     )
+    config.addinivalue_line(
+        "markers",
+        "remote_only: run test only in case of remote execution, otherwise skip"
+    )
 
 
 TestRun.configure = __configure
@@ -89,6 +93,10 @@ def __setup(cls, dut_config):
             raise Exception("There is no credentials in config file.")
     else:
         cls.executor = LocalExecutor()
+
+    if list(cls.item.iter_markers(name="remote_only")):
+        if not cls.executor.is_remote():
+            pytest.skip()
 
     if 'disks' not in dut_config:
         dut_config["disks"] = disk_finder.find_disks()


### PR DESCRIPTION
This marker should be used for tests which are required to
be run in remote environment (e.g. tests performing DUT reboot).

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>