### PR TITLE
Sort disks in DUT by type (from highest to lowest)

### DIFF
--- a/test_utils/dut.py
+++ b/test_utils/dut.py
@@ -13,6 +13,7 @@ class Dut:
                                    DiskType[disk_info['type']],
                                    disk_info['serial'],
                                    disk_info['blocksize']))
+        self.disks.sort(key=lambda disk: disk.disk_type, reverse=True)
 
         self.ipmi = dut_info['ipmi'] if 'ipmi' in dut_info else None
         self.spider = dut_info['spider'] if 'spider' in dut_info else None


### PR DESCRIPTION
That will cause that tests will use highest possible disk configuration
by simply getting first matching disk from the list.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>