### PR TITLE
Separate common functions into modules

### DIFF
--- a/test_utils/os_utils.py
+++ b/test_utils/os_utils.py
@@ -10,6 +10,7 @@ from packaging import version
 
 from core.test_run import TestRun
 from test_utils.filesystem.file import File
+from test_tools import fs_utils
 
 
 class DropCachesMode(IntFlag):
@@ -106,3 +107,27 @@ def sync():
     if output.exit_code != 0:
         raise Exception(
             f"Sync command failed. stdout: {output.stdout} \n stderr :{output.stderr}")
+
+
+def check_files(core, size_before, permissions_before, md5_before, mount_point='/big/cas/',
+                test_file_path=f"/mnt/cas/test_file"):
+    TestRun.LOGGER.info("Checking file md5.")
+    core.mount(mount_point)
+    file_after = fs_utils.parse_ls_output(fs_utils.ls(test_file_path))[0]
+    md5_after = file_after.md5sum()
+    if md5_before != md5_after:
+        TestRun.LOGGER.error(f"Md5 before ({md5_before}) and after ({md5_after}) are different.")
+
+    if permissions_before.user == file_after.permissions.user:
+        TestRun.LOGGER.error(f"User permissions before ({permissions_before.user}) "
+                             f"and after ({file_after.permissions.user}) are different.")
+    if permissions_before.group != file_after.permissions.group:
+        TestRun.LOGGER.error(f"Group permissions before ({permissions_before.group}) "
+                             f"and after ({file_after.permissions.group}) are different.")
+    if permissions_before.other != file_after.permissions.other:
+        TestRun.LOGGER.error(f"Other permissions before ({permissions_before.other}) "
+                             f"and after ({file_after.permissions.other}) are different.")
+    if size_before != file_after.size:
+        TestRun.LOGGER.error(f"Size before ({size_before}) and after ({file_after.size}) "
+                             f"are different.")
+    core.unmount()

--- a/test_utils/prepare.py
+++ b/test_utils/prepare.py
@@ -1,0 +1,39 @@
+#
+# Copyright(c) 2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+from api.cas import casadm
+from test_tools.disk_utils import Filesystem
+from test_utils.filesystem.file import File
+from core.test_run import TestRun
+from test_utils.size import Size, Unit
+
+
+def prepare():
+    cache_dev = TestRun.disks['cache']
+    cache_dev.create_partitions([Size(2, Unit.GibiByte)])
+    core_dev = TestRun.disks['core']
+    core_dev.create_partitions([Size(1, Unit.GibiByte)])
+    return cache_dev.partitions[0], core_dev.partitions[0]
+
+
+def prepare_with_file_creation(config, mount_point="/mnt/cas", test_file_path=f"/mnt/cas/test_file",
+                               fs=Filesystem.ext3):
+    TestRun.LOGGER.info("Prepare cache and core. Start Open CAS.")
+    cache_dev, core_dev = prepare()
+    cache = casadm.start_cache(cache_dev, config, force=True)
+    TestRun.LOGGER.info("Add core device, create filesystem and mount core.")
+    core = cache.add_core(core_dev)
+    core.create_filesystem(fs)
+    core.mount(mount_point)
+    TestRun.LOGGER.info(f"Create test file in {mount_point} directory and count its md5 sum.")
+    file = File.create_file(test_file_path)
+    file.write("Test content")
+    md5_before_load = file.md5sum()
+    size_before_load = file.size
+    permissions_before_load = file.permissions
+    TestRun.LOGGER.info("Release core.")
+    core.unmount()
+    return cache, core, md5_before_load, size_before_load, \
+        permissions_before_load, core_dev


### PR DESCRIPTION
Separate cache's prepare functions into apart module named 'prepare'.
Separate 'check_files' function into 'os_utils' module.

Signed-off-by: Slawomir_Jankowski <slawomir.jankowski@intel.com>