### PR TITLE
scsi_debug device creation

### DIFF
--- a/core/test_run_utils.py
+++ b/core/test_run_utils.py
@@ -4,17 +4,17 @@
 #
 
 
+import traceback
+
 import pytest
 from IPy import IP
 
-from connection.ssh_executor import SshExecutor
+import core.test_run
 from connection.local_executor import LocalExecutor
+from connection.ssh_executor import SshExecutor
 from storage_devices.disk import Disk
 from test_utils import disk_finder
 from test_utils.dut import Dut
-import core.test_run
-import traceback
-
 
 TestRun = core.test_run.TestRun
 
@@ -29,6 +29,12 @@ def __configure(cls, config):
         "markers",
         "remote_only: run test only in case of remote execution, otherwise skip"
     )
+    # scsi_debug_params are standard scsi_debug kernel module parameters given as kwargs
+    config.addinivalue_line(
+        "markers",
+        "scsi_debug_params: create scsi_debug devices with provided "
+        "parameters"
+    )
 
 
 TestRun.configure = __configure
@@ -41,6 +47,12 @@ def __prepare(cls, item):
     cls.req_disks = dict(req_disks)
     if len(req_disks) != len(cls.req_disks):
         raise Exception("Disk name specified more than once!")
+
+    scsi_params = \
+        list(map(lambda mark: mark.kwargs, cls.item.iter_markers(name="scsi_debug_params")))
+    if len(scsi_params):
+        cls.scsi_params = scsi_params[0]
+        cls.scsi_params["opts"] = "1"
 
 
 TestRun.prepare = __prepare

--- a/storage_devices/device.py
+++ b/storage_devices/device.py
@@ -4,8 +4,8 @@
 #
 
 
-from test_tools import disk_utils
 from core.test_run import TestRun
+from test_tools import disk_utils
 from test_utils.size import Size, Unit
 
 
@@ -50,3 +50,8 @@ class Device:
         from test_tools import fs_utils
         output = fs_utils.ls(f"$(find -L {directory} -samefile {self.system_path})")
         return fs_utils.parse_ls_output(output, self.system_path)
+
+    @staticmethod
+    def get_scsi_devices():
+        scsi_devices = TestRun.executor.run("lsscsi | grep Linux").stdout
+        return [Device(scsi_device.split()[-1]) for scsi_device in scsi_devices.splitlines()]


### PR DESCRIPTION
+ Added marker for scsi_debug parameters
Marker accepts standard scsi_debug module parameters as kwargs
example:
@pytest.mark.scsi_debug_params(add_host=2, dev_size_mb=500)
+ Added getting list of scsi_debug devices

Signed-off-by: Daniel Madej <daniel.madej@intel.com>