### PR TITLE
fio_param: Add two new paramaters to fio

### DIFF
--- a/test_tools/fio/fio_param.py
+++ b/test_tools/fio/fio_param.py
@@ -93,6 +93,13 @@ class FioParam(LinuxCommand):
     def block_size(self, size: Size):
         return self.set_param('blocksize', int(size))
 
+    def blocksize_range(self, ranges):
+        value = []
+        for bs_range in ranges:
+            str_range = str(int(bs_range[0])) + '-' + str(int(bs_range[1]))
+            value.append(str_range)
+        return self.set_param('blocksize_range', ",".join(value))
+
     def bs_split(self, value):
         return self.set_param('bssplit', value)
 
@@ -125,6 +132,13 @@ class FioParam(LinuxCommand):
 
     def file_size(self, size: Size):
         return self.set_param('filesize', int(size))
+
+    def file_size_range(self, ranges):
+        value = []
+        for bs_range in ranges:
+            str_range = str(int(bs_range[0])) + '-' + str(int(bs_range[1]))
+            value.append(str_range)
+        return self.set_param('filesize', ",".join(value))
 
     def fsync(self, value: int):
         return self.set_param('fsync', value)


### PR DESCRIPTION
Add two new paramaters to fio:
- blocksize_range: allows pass range of block sizes to fio
- file_size_range: allows pass range of file sizes to fio

Signed-off-by: Marcin Dziegielewski <marcin.dziegielewski@intel.com>