### PR TITLE
Change 'create_filesystem' function in 'disk_utils' module

### DIFF
--- a/storage_devices/device.py
+++ b/storage_devices/device.py
@@ -17,8 +17,8 @@ class Device:
         self.mount_point = None
 
     def create_filesystem(self, fs_type: disk_utils.Filesystem, force=True, blocksize=None):
-        if disk_utils.create_filesystem(self, fs_type, force, blocksize):
-            self.filesystem = fs_type
+        disk_utils.create_filesystem(self, fs_type, force, blocksize)
+        self.filesystem = fs_type
 
     def is_mounted(self):
         output = TestRun.executor.run(f"findmnt {self.system_path}")


### PR DESCRIPTION
Wrapper for this checks if this function completes with success, but it isn't return anything.
Now this function changes 'filesystem' property of given object, not the wrapper. Before that change, 'filesystem' property didn't change in object of 'device' class (or subclasses).

Signed-off-by: Ostrokrzew <slawomir.jankowski@intel.com>