### PR TITLE
scsi_debug device plugin

### DIFF
--- a/internal_plugins/scsi_debug/__init__.py
+++ b/internal_plugins/scsi_debug/__init__.py
@@ -1,0 +1,38 @@
+#
+# Copyright(c) 2020 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+from time import sleep
+
+from core.test_run_utils import TestRun
+from storage_devices.device import Device
+from test_utils import os_utils
+from test_utils.output import CmdException
+
+
+class ScsiDebug:
+    def __init__(self, params):
+        self.params = params
+        self.module_name = "scsi_debug"
+
+    def pre_setup(self):
+        pass
+
+    def post_setup(self):
+        self.teardown()
+        sleep(1)
+        load_output = os_utils.load_kernel_module(self.module_name, self.params)
+        if load_output.exit_code != 0:
+            raise CmdException(f"Failed to load {self.module_name} module", load_output)
+        TestRun.LOGGER.info(f"{self.module_name} loaded successfully.")
+        sleep(10)
+        TestRun.scsi_debug_devices = Device.get_scsi_debug_devices()
+
+    def teardown(self):
+        unload_output = os_utils.unload_kernel_module(self.module_name)
+        if unload_output.exit_code != 0 \
+                and "is not currently loaded" not in unload_output.stderr:
+            TestRun.LOGGER.info(f"Failed to unload {self.module_name} module\n{unload_output}")
+
+
+plugin_class = ScsiDebug

--- a/storage_devices/device.py
+++ b/storage_devices/device.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
 
-
-from test_tools import disk_utils
 from core.test_run import TestRun
+from test_tools import disk_utils
 from test_utils.size import Size, Unit
 
 
@@ -50,3 +49,8 @@ class Device:
         from test_tools import fs_utils
         output = fs_utils.ls(f"$(find -L {directory} -samefile {self.system_path})")
         return fs_utils.parse_ls_output(output, self.system_path)
+
+    @staticmethod
+    def get_scsi_debug_devices():
+        scsi_debug_devices = TestRun.executor.run_expect_success("lsscsi | grep scsi_debug").stdout
+        return [Device(device.split()[-1]) for device in scsi_debug_devices.splitlines()]


### PR DESCRIPTION
Plugin loads scsi_debug module and exposes created devices
through TestRun.scsi_debug_devices.

Use require_plugin mark with scsi_debug module parameters as kwargs.
Example:
@pytest.mark.require_plugin("scsi_debug", add_host=2, dev_size_mb=400)

Signed-off-by: Daniel Madej <daniel.madej@intel.com>