### PR TITLE
Fix timedelta precision by importing attotimedelta instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ typing==3.7.4.1
 pyyaml>=5.1
 lxml>=4.4.1
 wget>=3.2
+attotime>=0.2.0


### PR DESCRIPTION
total_seconds() method from Python's datetime class outputs a Float
precision number which for some numbers multiplied by 10^n gives wrong
values.
total_seconds() method from attotime class wraps a native method and
outputs a Decimal precision number which fixes this issue.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>