### PR TITLE
Change 4kiB blocks unit parsing

### DIFF
--- a/test_utils/size.py
+++ b/test_utils/size.py
@@ -16,7 +16,7 @@ def parse_unit(str_unit: str):
 
     if str_unit == "KiB":
         return Unit.KibiByte
-    elif str_unit == "4KiB Blocks":
+    elif str_unit.lower() == "4kib blocks":
         return Unit.Blocks4096
     elif str_unit == "MiB":
         return Unit.MebiByte


### PR DESCRIPTION
On some devices where cache's size value is passed as '4KiB blocks
which was unable to parse. We'd rather not meet case, where device's size is passed as 4 kibibits,
so I think comparing lower cases is safe.

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>