### PR TITLE
Custom class for time representation.

### DIFF
--- a/test_utils/time.py
+++ b/test_utils/time.py
@@ -1,0 +1,11 @@
+#
+# Copyright(c) 2019-2020 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+
+from attotime import attotimedelta
+
+
+class Time(attotimedelta):
+    def total_microseconds(self):
+        self.total_nanoseconds() / 1000


### PR DESCRIPTION
Builtin python types don't have capabilities to retrieve nanoseconds.

Signed-off-by: Michal Mielewczyk <michal.mielewczyk@intel.com>