### PR TITLE
Fix gathering of 'messages' log

### DIFF
--- a/connection/base_executor.py
+++ b/connection/base_executor.py
@@ -18,6 +18,14 @@ class BaseExecutor:
     def rsync(self, src, dst, delete, symlinks, exclude_list, timeout):
         raise NotImplementedError()
 
+    def rsync_to(self, src, dst, delete=False, symlinks=False, exclude_list=[],
+                 timeout: timedelta = timedelta(seconds=30)):
+        return self.rsync(src, dst, delete, symlinks, exclude_list, timeout, False)
+
+    def rsync_from(self, src, dst, delete=False, symlinks=False, exclude_list=[],
+                 timeout: timedelta = timedelta(seconds=30)):
+        return self.rsync(src, dst, delete, symlinks, exclude_list, timeout, True)
+
     def is_remote(self):
         return False
 

--- a/connection/local_executor.py
+++ b/connection/local_executor.py
@@ -24,7 +24,7 @@ class LocalExecutor(BaseExecutor):
                       completed_process.returncode)
 
     def rsync(self, src, dst, delete=False, symlinks=False, exclude_list=[],
-              timeout: timedelta = timedelta(seconds=30)):
+              timeout: timedelta = timedelta(seconds=30), dut_to_controller=False):
         options = []
 
         if delete:

--- a/connection/ssh_executor.py
+++ b/connection/ssh_executor.py
@@ -52,7 +52,7 @@ class SshExecutor(BaseExecutor):
         return Output(stdout.read(), stderr.read(), stdout.channel.recv_exit_status())
 
     def rsync(self, src, dst, delete=False, symlinks=False, exclude_list=[],
-              timeout: timedelta = timedelta(seconds=30)):
+              timeout: timedelta = timedelta(seconds=30), dut_to_controller=False):
         options = []
 
         if delete:
@@ -67,7 +67,9 @@ class SshExecutor(BaseExecutor):
             f'sshpass -p "{self.password}" '
             f'rsync -r -e "ssh -p {self.port} -o UserKnownHostsFile=/dev/null '
             f'-o StrictHostKeyChecking=no" '
-            f'{src} {self.user}@{self.ip}:{dst} {" ".join(options)}',
+            f'{self.user}@{self.ip}:{src} {dst} ' if dut_to_controller else
+                f'{src} {self.user}@{self.ip}:{dst} '
+            f'{" ".join(options)}',
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/log/logger.py
+++ b/log/logger.py
@@ -177,7 +177,11 @@ class Log(HtmlLogManager, metaclass=Singleton):
         from core.test_run import TestRun
         from connection.ssh_executor import SshExecutor
         from connection.local_executor import LocalExecutor
-        log_files = {"messages": "/var/log/messages",
+        from test_tools.fs_utils import check_if_file_exists
+        messages_log = "/var/log/messages"
+        if not check_if_file_exists(messages_log):
+            messages_log = "/var/log/syslog"
+        log_files = {"messages": messages_log,
                      "dmesg": "/home/user/dmesg",
                      "cas": "/var/log/opencas.log"}
         TestRun.executor.run(f"dmesg > {log_files['dmesg']}")
@@ -185,12 +189,7 @@ class Log(HtmlLogManager, metaclass=Singleton):
         for key in log_files.keys():
             try:
                 log_destination_path = os.path.join(self.base_dir, "dut_info", f'{key}.log')
-                if type(TestRun.executor) is SshExecutor:
-                    sftp = TestRun.executor.ssh.open_sftp()
-                    sftp.get(log_files[key], log_destination_path)
-                    sftp.close()
-                elif type(TestRun.executor) is LocalExecutor:
-                    TestRun.executor.run(f"cp {log_files[key]} {log_destination_path}")
+                TestRun.executor.rsync_from(log_files[key], log_destination_path)
             except Exception as e:
                 TestRun.LOGGER.warning(f"There was a problem during gathering {key} log.\n"
                                        f"{str(e)}")


### PR DESCRIPTION
On Linux systems using journald instead of syslog (e.g. Ubuntu) there's
no /var/log/messages log, so we need to gather /var/log/syslog instead,
which also contains everything that used to be in /var/log/messages.