### PR TITLE
ssh_executor: Catch any exception on wait_for_connection_loss()

### DIFF
--- a/connection/ssh_executor.py
+++ b/connection/ssh_executor.py
@@ -118,6 +118,6 @@ class SshExecutor(BaseExecutor):
                 self.disconnect()
                 try:
                     self.connect(timeout=timedelta(seconds=5))
-                except (ConnectionResetError, NoValidConnectionsError):
+                except Exception:
                     return
             raise ConnectionError("Timeout occurred before ssh connection loss")


### PR DESCRIPTION
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>