### PR TITLE
Unload scsi_debug kernel module only when it is loaded

### DIFF
--- a/internal_plugins/scsi_debug/__init__.py
+++ b/internal_plugins/scsi_debug/__init__.py
@@ -21,12 +21,6 @@ class ScsiDebug:
     def post_setup(self):
         self.reload()
 
-    def teardown(self):
-        unload_output = os_utils.unload_kernel_module(self.module_name)
-        if unload_output.exit_code != 0 \
-                and "is not currently loaded" not in unload_output.stderr:
-            TestRun.LOGGER.info(f"Failed to unload {self.module_name} module\n{unload_output}")
-
     def reload(self):
         self.teardown()
         sleep(1)
@@ -36,6 +30,10 @@ class ScsiDebug:
         TestRun.LOGGER.info(f"{self.module_name} loaded successfully.")
         sleep(10)
         TestRun.scsi_debug_devices = Device.get_scsi_debug_devices()
+
+    def teardown(self):
+        if os_utils.is_kernel_module_loaded(self.module_name):
+            os_utils.unload_kernel_module(self.module_name)
 
 
 plugin_class = ScsiDebug


### PR DESCRIPTION
Signed-off-by: Katarzyna Lapinska <katarzyna.lapinska@intel.com>