### PR TITLE
Revert "Update size.py"

### DIFF
--- a/test_utils/size.py
+++ b/test_utils/size.py
@@ -16,7 +16,7 @@ def parse_unit(str_unit: str):
 
     if str_unit == "KiB":
         return Unit.KibiByte
-    elif str_unit == "4KiB Blocks":
+    elif str_unit in ["4KiB blocks", "4KiB Blocks"]:
         return Unit.Blocks4096
     elif str_unit == "MiB":
         return Unit.MebiByte


### PR DESCRIPTION
In older CAS versions statistics both `4Kib blocks` and `4KiB Blocks` may occur

This reverts commit 48c22dab60ec985a2381f496668a79dd83698c29.