### PR TITLE
Fix for removing partition

### DIFF
--- a/core/test_run_utils.py
+++ b/core/test_run_utils.py
@@ -65,7 +65,6 @@ def __setup_disk(cls, disk_name, disk_type):
     ))
     if not cls.disks[disk_name]:
         pytest.skip("Unable to find requested disk!")
-    cls.disks[disk_name].remove_partitions()
 
 
 TestRun.__setup_disk = __setup_disk


### PR DESCRIPTION
Removing partitions is removed here, because this method is called before the test prepare which is placed in the conftest. There is unmounting devices, killing I/O processes etc, and after those actions partitions are being removed also.

Signed-off-by: Katarzyna Lapinska <katarzyna.lapinska@intel.com>