### PR TITLE
logger: Use /tmp/ path to create temporary file

### DIFF
--- a/log/logger.py
+++ b/log/logger.py
@@ -182,7 +182,7 @@ class Log(HtmlLogManager, metaclass=Singleton):
         if not check_if_file_exists(messages_log):
             messages_log = "/var/log/syslog"
         log_files = {"messages": messages_log,
-                     "dmesg": "/home/user/dmesg",
+                     "dmesg": "/tmp/dmesg",
                      "cas": "/var/log/opencas.log"}
         TestRun.executor.run(f"dmesg > {log_files['dmesg']}")
 


### PR DESCRIPTION
Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>