### PR TITLE
Solve partitions removal error

### DIFF
--- a/test_tools/disk_utils.py
+++ b/test_tools/disk_utils.py
@@ -230,12 +230,7 @@ def remove_partitions(device):
         unmount(partition)
 
     TestRun.LOGGER.info(f"Removing partitions from device: {device.path}.")
-    dd = Dd().input("/dev/zero") \
-        .output(device.path) \
-        .count(1) \
-        .block_size(Size(1, Unit.Blocks4096))\
-        .oflag("direct")
-    dd.run()
+    device.wipe_filesystem()
     output = TestRun.executor.run(f"ls {device.path}* -1")
     if len(output.stdout.split('\n')) > 1:
         TestRun.LOGGER.error(f"Could not remove partitions from device {device.path}")
@@ -287,13 +282,12 @@ def unit_to_string(unit):
 
 
 def wipe_filesystem(device, force=True):
-    TestRun.LOGGER.info(
-        f"Deleting filesystem ({device.filesystem.name}) on device: {device.path}")
+    TestRun.LOGGER.info(f"Erasing the device: {device.path}")
     force_param = ' -f' if force else ''
     cmd = f'wipefs -a{force_param} {device.path}'
     TestRun.executor.run_expect_success(cmd)
     TestRun.LOGGER.info(
-        f"Successfully wiped filesystem from device: {device.path}")
+        f"Successfully wiped device: {device.path}")
 
 
 def get_device_filesystem_type(device_id):

--- a/test_tools/disk_utils.py
+++ b/test_tools/disk_utils.py
@@ -223,6 +223,7 @@ def get_first_partition_offset(device, aligned: bool):
 
 
 def remove_partitions(device):
+    from test_utils.os_utils import Udev
     if device.is_mounted():
         device.unmount()
 
@@ -231,6 +232,7 @@ def remove_partitions(device):
 
     TestRun.LOGGER.info(f"Removing partitions from device: {device.path}.")
     device.wipe_filesystem()
+    Udev.trigger_settle()
     output = TestRun.executor.run(f"ls {device.path}* -1")
     if len(output.stdout.split('\n')) > 1:
         TestRun.LOGGER.error(f"Could not remove partitions from device {device.path}")

--- a/test_utils/os_utils.py
+++ b/test_utils/os_utils.py
@@ -135,6 +135,10 @@ class Udev(object):
         TestRun.LOGGER.info("Disabling udev")
         TestRun.executor.run_expect_success("udevadm control --stop-exec-queue")
 
+    @staticmethod
+    def trigger_settle():
+        TestRun.executor.run_expect_success("udevadm trigger && udevadm settle")
+
 
 def drop_caches(level: DropCachesMode = DropCachesMode.PAGECACHE):
     TestRun.executor.run_expect_success(


### PR DESCRIPTION
According to manual, `wipefs` can erase a filesystem or partition table
so replacing `dd` with `wipefs` solves errors in test preparation.

Signed-off-by: Slawomir Jankowski <slawomir.jankowski@intel.com>