### PR TITLE
Run instead of run_expect_success for disabling memory affecting functions

### DIFF
--- a/test_utils/os_utils.py
+++ b/test_utils/os_utils.py
@@ -152,10 +152,10 @@ def drop_caches(level: DropCachesMode = DropCachesMode.PAGECACHE):
 def disable_memory_affecting_functions():
     """Disables system functions affecting memory"""
     # Don't allow sshd to be killed in case of out-of-memory:
-    TestRun.executor.run_expect_success(
+    TestRun.executor.run(
         "echo '-1000' > /proc/`cat /var/run/sshd.pid`/oom_score_adj"
     )
-    TestRun.executor.run_expect_success(
+    TestRun.executor.run(
         "echo -17 > /proc/`cat /var/run/sshd.pid`/oom_adj"
     )  # deprecated
     TestRun.executor.run_expect_success(


### PR DESCRIPTION
On some OSes there is no file /var/run/sshd.pid and those functions which are using it don't need to be executed with success.


Signed-off-by: klapinsk <katarzyna.lapinska@intel.com>