### PR TITLE
Fix for args being passed down incorrectly in start_async_func()

### DIFF
--- a/test_utils/asynchronous.py
+++ b/test_utils/asynchronous.py
@@ -12,4 +12,4 @@ def start_async_func(func, *args):
     actual result after being awaited.
     """
     loop = asyncio.get_event_loop()
-    return loop.run_in_executor(None, func, args)
+    return loop.run_in_executor(None, func, *args)


### PR DESCRIPTION
Signed-off-by: Daniel Madej <daniel.madej@intel.com>