### PR TITLE
Small ssh and ip changes

### DIFF
--- a/connection/ssh_executor.py
+++ b/connection/ssh_executor.py
@@ -31,7 +31,8 @@ class SshExecutor(BaseExecutor):
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
             self.ssh.connect(self.ip, username=user,
-                             port=port, timeout=timeout.total_seconds())
+                             port=port, timeout=timeout.total_seconds(),
+                             banner_timeout=timeout.total_seconds())
         except paramiko.AuthenticationException as e:
             raise paramiko.AuthenticationException(
                 f"Authentication exception occurred while trying to connect to DUT. "

--- a/test_utils/dut.py
+++ b/test_utils/dut.py
@@ -20,10 +20,10 @@ class Dut:
         self.spider = dut_info['spider'] if 'spider' in dut_info else None
         self.wps = dut_info['wps'] if 'wps' in dut_info else None
         self.env = dut_info['env'] if 'env' in dut_info else None
-        self.ip = dut_info['ip'] if 'ip' in dut_info else None
+        self.ip = dut_info['ip'] if 'ip' in dut_info else "127.0.0.1"
 
     def __str__(self):
-        dut_str = f'ip: {self.ip}\n' if self.ip is not None else ''
+        dut_str = f'ip: {self.ip}\n'
         dut_str += f'ipmi: {self.ipmi["ip"]}\n' if self.ipmi is not None else ''
         dut_str += f'spider: {self.spider["ip"]}\n' if self.spider is not None else ''
         dut_str += f'wps: {self.wps["ip"]} port: {self.wps["port"]}\n' \


### PR DESCRIPTION
Add banner_timeout to paramiko connect in order to wait for inactive
host. Otherwise paramiko raises double exception which cannot be
handled.
Also replace None to localhost ip in dut.ip in Local mode, as it's real
Dut ip in Local mode and can be used for network communication in some
cases.

Signed-off-by: Oleksandr Shchirskyi <oleksand.shchirskyi@intel.com>