### PR TITLE
Fix for counting disk size using linux sector size instead of disk block size

### DIFF
--- a/test_tools/disk_utils.py
+++ b/test_tools/disk_utils.py
@@ -18,6 +18,9 @@ from test_utils.output import CmdException
 from test_utils.size import Size, Unit
 
 
+SECTOR_SIZE = 512
+
+
 class Filesystem(Enum):
     xfs = 0
     ext3 = 1
@@ -172,7 +175,7 @@ def get_block_size(device):
 def get_size(device):
     output = TestRun.executor.run_expect_success(f"cat {get_sysfs_path(device)}/size")
     blocks_count = int(output.stdout)
-    return blocks_count * int(get_block_size(device))
+    return blocks_count * SECTOR_SIZE
 
 
 def get_sysfs_path(device):


### PR DESCRIPTION
Signed-off-by: klapinsk <katarzyna.lapinska@intel.com>