### PR TITLE
Non vm fio

### DIFF
--- a/test_tools/fio/fio.py
+++ b/test_tools/fio/fio.py
@@ -97,9 +97,9 @@ class Fio:
                 f" {str(self.base_cmd_parameters)} -"
         else:
             fio_parameters = test_tools.fio.fio_param.FioParamCmd(self, self.executor)
-            fio_parameters.command_env_var_dict.update(self.base_cmd_parameters.command_env_var_dict)
-            fio_parameters.command_param_dict.update(self.base_cmd_parameters.command_param_dict)
-            fio_parameters.command_param_dict.update(self.global_cmd_parameters.command_param_dict)
+            fio_parameters.command_env_var.update(self.base_cmd_parameters.command_env_var)
+            fio_parameters.command_param.update(self.base_cmd_parameters.command_param)
+            fio_parameters.command_param.update(self.global_cmd_parameters.command_param)
             fio_parameters.command_flags.extend(self.global_cmd_parameters.command_flags)
             fio_parameters.set_param('name', 'fio')
             command = str(fio_parameters)

--- a/test_tools/fio/fio.py
+++ b/test_tools/fio/fio.py
@@ -97,6 +97,7 @@ class Fio:
                 f" {str(self.base_cmd_parameters)} -"
         else:
             fio_parameters = test_tools.fio.fio_param.FioParamCmd(self, self.executor)
+            fio_parameters.command_env_var_dict.update(self.base_cmd_parameters.command_env_var_dict)
             fio_parameters.command_param_dict.update(self.base_cmd_parameters.command_param_dict)
             fio_parameters.command_param_dict.update(self.global_cmd_parameters.command_param_dict)
             fio_parameters.command_flags.extend(self.global_cmd_parameters.command_flags)

--- a/test_tools/fio/fio_param.py
+++ b/test_tools/fio/fio_param.py
@@ -55,7 +55,9 @@ class IoEngine(Enum):
     # File is memory mapped with mmap and data copied using memcpy.
     mmap = 6,
     # RADOS Block Device
-    rbd = 7
+    rbd = 7,
+    # SPDK Block Device
+    spdk_bdev = 8
 
 
 class ReadWrite(Enum):
@@ -254,8 +256,17 @@ class FioParam(LinuxCommand):
     def lat_percentiles(self, value: bool):
         return self.set_param('lat_percentiles', int(value))
 
+    def scramble_buffers(self, value: bool):
+        return self.set_param('scramble_buffers', int(value))
+
     def slat_percentiles(self, value: bool):
         return self.set_param('slat_percentiles', int(value))
+
+    def spdk_core_mask(self, value: str):
+        return self.set_param('spdk_core_mask', value)
+
+    def spdk_json_conf(self, path):
+        return self.set_param('spdk_json_conf', path)
 
     def clat_percentiles(self, value: bool):
         return self.set_param('clat_percentiles', int(value))

--- a/test_tools/fio/fio_param.py
+++ b/test_tools/fio/fio_param.py
@@ -125,7 +125,7 @@ class FioParam(LinuxCommand):
         return self.set_param('cpus_allowed_policy', value.name)
 
     def direct(self, value: bool = True):
-        if 'buffered' in self.command_param_dict:
+        if 'buffered' in self.command_param:
             self.remove_param('buffered')
         return self.set_param('direct', int(value))
 
@@ -168,15 +168,15 @@ class FioParam(LinuxCommand):
 
     def io_depth(self, value: int):
         if value != 1:
-            if 'ioengine' in self.command_param_dict and \
-                    self.command_param_dict['ioengine'] == 'sync':
+            if 'ioengine' in self.command_param and \
+                    self.command_param['ioengine'] == 'sync':
                 TestRun.LOGGER.warning("Setting iodepth will have no effect with "
                                               "'ioengine=sync' setting")
         return self.set_param('iodepth', value)
 
     def io_engine(self, value: IoEngine):
         if value == IoEngine.sync:
-            if 'iodepth' in self.command_param_dict and self.command_param_dict['iodepth'] != 1:
+            if 'iodepth' in self.command_param and self.command_param['iodepth'] != 1:
                 TestRun.LOGGER.warning("Setting 'ioengine=sync' will cause iodepth setting "
                                               "to be ignored")
         return self.set_param('ioengine', value.name)
@@ -188,7 +188,7 @@ class FioParam(LinuxCommand):
         return self.set_param('loops', value)
 
     def no_random_map(self, value: bool = True):
-        if 'verify' in self.command_param_dict:
+        if 'verify' in self.command_param:
             raise ValueError("'NoRandomMap' parameter is mutually exclusive with verify")
         if value:
             return self.set_flags('norandommap')
@@ -329,7 +329,7 @@ class FioParam(LinuxCommand):
         return self.fio.global_cmd_parameters
 
     def run(self, fio_timeout: datetime.timedelta = None):
-        if "per_job_logs" in self.fio.global_cmd_parameters.command_param_dict:
+        if "per_job_logs" in self.fio.global_cmd_parameters.command_param:
             self.fio.global_cmd_parameters.set_param("per_job_logs", '0')
         fio_output = self.fio.run(fio_timeout)
         if fio_output.exit_code != 0:
@@ -341,7 +341,7 @@ class FioParam(LinuxCommand):
         return self.get_results(out)
 
     def run_in_background(self):
-        if "per_job_logs" in self.fio.global_cmd_parameters.command_param_dict:
+        if "per_job_logs" in self.fio.global_cmd_parameters.command_param:
             self.fio.global_cmd_parameters.set_param("per_job_logs", '0')
         return self.fio.run_in_background()
 

--- a/test_utils/linux_command.py
+++ b/test_utils/linux_command.py
@@ -9,14 +9,14 @@ from collections import defaultdict
 class LinuxCommand:
     def __init__(self, command_executor, command_name):
         self.command_executor = command_executor
-        self.command_param_dict = defaultdict(list)
+        self.command_param = defaultdict(list)
         self.command_flags = []
         self.command_name = command_name
         self.param_name_prefix = ''
         self.param_separator = ' '
         self.param_value_prefix = '='
         self.param_value_list_separator = ','
-        self.command_env_var_dict = defaultdict(list)
+        self.command_env_var = defaultdict(list)
         self.env_var_separator = ' '
         self.env_var_value_prefix = '='
 
@@ -40,38 +40,38 @@ class LinuxCommand:
         self.remove_param(key)
 
         for val in values:
-            self.command_param_dict[key].append(str(val))
+            self.command_param[key].append(str(val))
         return self
 
     def remove_param(self, key):
-        if key in self.command_param_dict:
-            del self.command_param_dict[key]
+        if key in self.command_param:
+            del self.command_param[key]
         return self
 
     def set_env_var(self, key, *values):
         self.remove_env_var(key)
 
         for val in values:
-            self.command_env_var_dict[key].append(str(val))
+            self.command_env_var[key].append(str(val))
         return self
 
     def remove_env_var(self, key):
-        if key in self.command_env_var_dict:
-            del self.command_env_var_dict[key]
+        if key in self.command_env_var:
+            del self.command_env_var[key]
         return self
 
     def get_parameter_value(self, param_name):
-        if param_name in self.command_param_dict.keys():
-            return self.command_param_dict[param_name]
+        if param_name in self.command_param.keys():
+            return self.command_param[param_name]
         return None
 
     def __str__(self):
         command = ''
-        for key, value in self.command_env_var_dict.items():
+        for key, value in self.command_env_var.items():
             command += f'{key}{self.env_var_value_prefix}{",".join(value)}' \
                        f'{self.env_var_separator}'
         command += self.command_name
-        for key, value in self.command_param_dict.items():
+        for key, value in self.command_param.items():
             command += f'{self.param_separator}{self.param_name_prefix}' \
                 f'{key}{self.param_value_prefix}{",".join(value)}'
         for flag in self.command_flags:

--- a/test_utils/linux_command.py
+++ b/test_utils/linux_command.py
@@ -16,6 +16,9 @@ class LinuxCommand:
         self.param_separator = ' '
         self.param_value_prefix = '='
         self.param_value_list_separator = ','
+        self.command_env_var_dict = defaultdict(list)
+        self.env_var_separator = ' '
+        self.env_var_value_prefix = '='
 
     def run(self):
         return self.command_executor.run(str(self))
@@ -45,13 +48,29 @@ class LinuxCommand:
             del self.command_param_dict[key]
         return self
 
+    def set_env_var(self, key, *values):
+        self.remove_env_var(key)
+
+        for val in values:
+            self.command_env_var_dict[key].append(str(val))
+        return self
+
+    def remove_env_var(self, key):
+        if key in self.command_env_var_dict:
+            del self.command_env_var_dict[key]
+        return self
+
     def get_parameter_value(self, param_name):
         if param_name in self.command_param_dict.keys():
             return self.command_param_dict[param_name]
         return None
 
     def __str__(self):
-        command = self.command_name
+        command = ''
+        for key, value in self.command_env_var_dict.items():
+            command += f'{key}{self.env_var_value_prefix}{",".join(value)}' \
+                       f'{self.env_var_separator}'
+        command += self.command_name
         for key, value in self.command_param_dict.items():
             command += f'{self.param_separator}{self.param_name_prefix}' \
                 f'{key}{self.param_value_prefix}{",".join(value)}'


### PR DESCRIPTION
Updating expected fio vesion to 3.27.
Adding missing "scramble_buffers" param to fio.
Adding 'spdk_core_mask' to 'spdk_json_conf' params to enable using fio without using VM and vhost block device.
Added option to add environmental variables into linux_command.