### PR TITLE
Fix for redirecting command's output to the file

### DIFF
--- a/connection/base_executor.py
+++ b/connection/base_executor.py
@@ -49,7 +49,7 @@ class BaseExecutor:
                           command,
                           stdout_redirect_path="/dev/null",
                           stderr_redirect_path="/dev/null"):
-        command += f"> {stdout_redirect_path} 2> {stderr_redirect_path} &echo $!"
+        command += f" > {stdout_redirect_path} 2> {stderr_redirect_path} &echo $!"
         output = self.run(command)
 
         if output is not None:


### PR DESCRIPTION
When the last command parameter is a number, there should be a space before redirection sign, otherwise it is recognized as the redirection type

Signed-off-by: klapinsk <katarzyna.lapinska@intel.com>