### PR TITLE
Add 10 second timeout for check_if_process_exists

### DIFF
--- a/connection/base_executor.py
+++ b/connection/base_executor.py
@@ -59,7 +59,7 @@ class BaseExecutor:
         self.run(f"tail --pid={pid} -f /dev/null", timeout)
 
     def check_if_process_exists(self, pid: int):
-        output = self.run(f"ps aux | awk '{{print $2 }}' | grep {pid}")
+        output = self.run(f"ps aux | awk '{{print $2 }}' | grep {pid}", timedelta(seconds=10))
         return True if output.exit_code == 0 else False
 
     def kill_process(self, pid: int):


### PR DESCRIPTION
With no timeout parameter the default 30 minutes is being used. The user of
the BaseExecutor class may find it too long for simple operation like checking
if process exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/test-framework/270)
<!-- Reviewable:end -->
