### PR TITLE
Kamilg/fix io stat parser

### DIFF
--- a/test_utils/io_stats.py
+++ b/test_utils/io_stats.py
@@ -8,7 +8,7 @@ from core.test_run import TestRun
 from test_utils.output import CmdException
 
 SYSFS_LINE_FORMAT = r"^(\d+\s+){10,}\d+$"
-PROCFS_LINE_FORMAT = r"^\d+\s+\d+\s+\w+\s+" + SYSFS_LINE_FORMAT[1:]
+PROCFS_LINE_FORMAT = r"^\d+\s+\d+\s+[\w-]+\s+" + SYSFS_LINE_FORMAT[1:]
 
 
 # This class represents block device I/O statistics.


### PR DESCRIPTION
Changing \w+ to [\\w-]+ allows the regex to match hyphens - in addition to alphanumeric characters. This means that a string like cas1-1 will now be correctly matched.